### PR TITLE
Add MCP Python runner validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ npm-debug.log*
 # Temporary files
 /tmp/
 .DS_Store
+
+# Generated from org files
+README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,35 +5,74 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build & Test Commands
 - **Build container**: `make build` - Creates Docker/Podman image
 - **Run environment**: `make run` - Starts container with mounted volumes
-- **Install MCP servers**: `./scripts/install-mcp-servers.sh` - Installs MCP server components
+- **Install MCP servers**: `./scripts/install-mcp-servers.sh` - Installs MCP server components 
 - **Check MCP setup**: `./scripts/check-mcp-setup.sh` - Verifies MCP CLI installation
 - **Test MCP servers**: `make test` - Verifies all MCP servers are working
+- **Run Python example**: `python scripts/mcp_simple_example.py` - Tests MCP Python runner
+- **Quick Python**: `./scripts/run_python_code <code>` - Run Python code directly
 - **Analyze algorithm**: `make analyze ALGO=algorithm_name` - Run analysis via MCP
-- **Direct Claude analysis**: `make claude-analyze ALGO=algorithm_name` - Local Claude analysis
-- **Run all tests**: `python -m pytest tests/` - Run all Python tests
-- **Single test**: `python -m pytest tests/test_file.py::test_name -v` - Run specific test
-- **Stop environment**: `make stop` - Stops and removes container
-- **Format code**: `black algorithms/ tests/` - Format Python code with Black
-- **Type check**: `mypy algorithms/ tests/` - Run type checking with mypy
-- **Lint code**: `flake8 algorithms/ tests/` - Run linting with flake8
+
+## Python Commands (using UV with Python 3.11)
+- **Install deps**: `make install-dev` - Install dependencies with UV
+- **Run all tests**: `make pytest` - Run all Python tests
+- **Single test**: `make PYTEST_ARGS="tests/test_factorial.py::test_factorial_recursive -v"` - Run specific test
+- **Test class**: `make PYTEST_ARGS="tests/test_factorial.py::TestClass -v"` - Run specific test class
+- **Skip slow tests**: `make PYTEST_ARGS="-m 'not slow'"` - Skip tests marked as slow
+- **Run all linters**: `make lint` - Run all linters (isort, black, mypy, flake8)
+- **Format code**: `make black` - Format Python code with Black (100 char line)
+- **Type check**: `make mypy` - Run type checking with mypy
 
 ## Code Style Guidelines
 - **Python**: PEP 8 with Black (100 char line length), type annotations required
-- **Docstrings**: Google style with Args/Returns sections and complexity analysis
+- **Docstrings**: Google style with Args/Returns sections and complexity analysis (time & space)
 - **Imports**: Group (stdlib → third-party → local) with blank line separation
 - **Error handling**: Use specific exception types, proper error propagation
-- **Naming**: snake_case for variables/functions, PascalCase for classes, kebab-case for scripts
-- **Testing**: pytest with parametrized tests, markers for slow/benchmark tests (`@pytest.mark.slow`, `@pytest.mark.benchmark`)
-- **Shebang lines**: Use `#!/usr/bin/env python3` for compatibility
+- **Naming**: snake_case for variables/functions, PascalCase for classes, kebab-case for shell scripts
+- **Testing**: pytest with parametrized tests, markers for slow/benchmark tests
+- **Shebang lines**: `#!/usr/bin/env python3` for compatibility
 - **Security**: No hardcoded credentials, use environment variables
 
 ## Git Commit Standards
 - Follow Conventional Commits: `<type>[scope]: <description>`
 - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `build`, `ci`
 - Use Git trailers instead of Co-authored-by in message body
-- Example: `git commit -m "feat(mcp): add python-lsp support" --trailer "Co-authored-by: Name <email>"`
 
-## FreeBSD Compatibility
-- Design for cross-platform compatibility
-- Use command detection: `DOCKER_CMD=$(command -v podman || command -v docker)`
-- Avoid Linux-specific path assumptions
+## Project Organization
+- **algorithms/**: Core algorithm implementations
+- **tests/**: Test files matching test_*.py pattern
+- **scripts/**: Utility scripts for setup and execution
+- **config/**: Configuration files for MCP and services
+
+## Algorithm Guidelines
+- **Time/Space Complexity**: Always include Big O notation in docstrings
+- **Multiple Implementations**: Provide various approaches (recursive, iterative, etc.)
+- **Benchmarking**: Include benchmark functions for performance comparison
+- **Documentation**: Add detailed explanation of algorithm logic and tradeoffs
+- **Types**: Use proper type annotations for all function parameters and returns
+- **Testing**: Create parametrized tests with known input/output values
+- **Primary Algorithms**:
+  - **Factorial**: Recursive, tail-recursive, memoized, iterative implementations
+  - **Fibonacci**: Recursive, memoized, iterative, generator implementations
+  - **Primes**: Naive testing, optimized testing, sieve algorithms
+
+## MCP Algorithm Analysis
+- **Run analysis**: `make analyze ALGO=algorithm_name` (e.g., `make analyze ALGO=fibonacci`)
+- **Analysis pipeline**:
+  1. LSP analysis via multilspy server to check code quality
+  2. Code execution via python-runner MCP server
+  3. Claude Code analysis of algorithm implementation
+- **Analysis questions**:
+  - Algorithmic complexity assessment
+  - Bug and inefficiency detection
+  - Implementation improvement suggestions
+  - Trade-offs between different approaches
+  - Unique implementation characteristics
+- **Output location**: Analysis results stored in `analysis_results/` directory
+
+## Claude Code Commands
+- **Algorithm comparison**: `/compare algorithms/factorial.py algorithms/fibonacci.py`
+- **Complexity analysis**: `/complexity-analysis algorithms/primes.py`
+- **Implementation suggestions**: `/suggest-optimizations algorithms/fibonacci.py`
+- **Adding new algorithm**: `/implement <algorithm_name> -t [time complexity] -s [space complexity]`
+- **Test generation**: `/generate-tests algorithms/primes.py`
+- **Benchmark execution**: `/benchmark algorithms/factorial.py` (runs benchmark and analyzes results)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,13 @@ description = "A secure, isolated environment for Python development with MCP an
 authors = [
     {name = "Aidan Pace", email = "apace@defrecord.com"}
 ]
-readme = "README.org"
-requires-python = ">=3.9"
+readme = "README.md"
+requires-python = ">=3.11"
 license = {text = "MIT"}
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.11",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
@@ -26,14 +26,14 @@ classifiers = [
 
 [tool.black]
 line-length = 100
-target-version = ["py39"]
+target-version = ["py311"]
 
 [tool.isort]
 profile = "black"
 line_length = 100
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/scripts/check-mcp-setup.sh
+++ b/scripts/check-mcp-setup.sh
@@ -5,22 +5,22 @@ set -e
 
 echo "Checking MCP setup..."
 
-# Check if poetry is installed
-if ! command -v poetry &> /dev/null; then
-    echo "Poetry not found. Installing..."
-    curl -sSL https://install.python-poetry.org | python3 -
+# Check if UV is installed
+if ! command -v uv &> /dev/null; then
+    echo "UV not found. Installing..."
+    curl -fsSL https://astral.sh/uv/install.sh | bash
 fi
 
 # Install MCP CLI if not already installed
-echo "Ensuring MCP CLI is installed..."
-poetry add "mcp[cli]"
+echo "Ensuring MCP CLI is installed with Python 3.11..."
+uv pip install --python=3.11 "mcp[cli]"
 
 # Run MCP setup check
 echo "Running MCP setup check..."
-poetry run python -m mcp.cli check
+uv run --python=3.11 -m mcp.cli check
 
 # Test run-python MCP server
 echo "Testing MCP run-python server..."
-poetry run python -m mcp.cli run-python --verify
+uv run --python=3.11 -m mcp.cli run-python --verify
 
 echo "MCP setup check complete."

--- a/scripts/install-mcp-servers.sh
+++ b/scripts/install-mcp-servers.sh
@@ -5,32 +5,65 @@ set -e
 
 echo "Installing MCP servers..."
 
-# Install simple MCP servers first
-echo "Installing Filesystem MCP server..."
-claude mcp add filesystem
+# Check and install Filesystem MCP server
+echo "Checking Filesystem MCP server..."
+if ! claude mcp list | grep -q "filesystem"; then
+    echo "Installing Filesystem MCP server..."
+    claude mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem ~/projects
+else
+    echo "Filesystem MCP server already installed."
+fi
 
-echo "Installing Memory MCP server..."
-claude mcp add memory
+# Check and install Memory MCP server
+echo "Checking Memory MCP server..."
+if ! claude mcp list | grep -q "memory"; then
+    echo "Installing Memory MCP server..."
+    claude mcp add memory -- npx -y @modelcontextprotocol/server-memory
+else
+    echo "Memory MCP server already installed."
+fi
 
-echo "Installing Github MCP server..."
-claude mcp add github
+# Check and install Github MCP server
+echo "Checking Github MCP server..."
+if ! claude mcp list | grep -q "github"; then
+    echo "Installing Github MCP server..."
+    claude mcp add github
+else
+    echo "Github MCP server already installed."
+fi
 
-# Install LSP servers
-echo "Installing Python LSP servers..."
-claude mcp add multilspy
-claude mcp add python-lsp
+# Check and install LSP servers
+echo "Checking Python LSP servers..."
+if ! claude mcp list | grep -q "multilspy"; then
+    echo "Installing Multi LSP server..."
+    claude mcp add multilspy
+else
+    echo "Multi LSP server already installed."
+fi
+
+if ! claude mcp list | grep -q "python-lsp"; then
+    echo "Installing Python LSP server..."
+    claude mcp add python-lsp
+else
+    echo "Python LSP server already installed."
+fi
 
 # Install prerequisites for Python Runner
 echo "Installing prerequisites..."
 npm install
 
-# Install Python Runner MCP server
-echo "Installing Python Runner MCP server..."
-claude mcp add python-runner -- \
-    deno run -N -R=node_modules -W=node_modules --node-modules-dir=auto \
-    jsr:@pydantic/mcp-run-python stdio
+# Check and install Python Runner MCP server
+echo "Checking Python Runner MCP server..."
+if ! claude mcp list | grep -q "python-runner"; then
+    echo "Installing Python Runner MCP server..."
+    claude mcp add python-runner -- \
+        deno run -N -R=node_modules -W=node_modules --node-modules-dir=auto \
+        jsr:@pydantic/mcp-run-python stdio
+else
+    echo "Python Runner MCP server already installed."
+fi
 
 echo "MCP servers installation complete."
 echo ""
-echo "To test the installation, run: claude mcp list"
+echo "To verify the installation, run: claude mcp list"
 echo "To start servers, run: ./scripts/start-mcp-servers.sh"

--- a/scripts/mcp_simple_example.py
+++ b/scripts/mcp_simple_example.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Simple example showing how to use MCP Python runner
+"""
+import asyncio
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# Example Python code to execute with numpy dependency
+code = """
+# /// script
+# dependencies = ["numpy"]
+# ///
+import numpy
+a = numpy.array([1, 2, 3])
+print(a)
+a
+"""
+
+# Configure server parameters based on the installation command
+server_params = StdioServerParameters(
+    command='deno',
+    args=[
+        'run',
+        '-N',
+        '-R=node_modules',
+        '-W=node_modules',
+        '--node-modules-dir=auto',
+        'jsr:@pydantic/mcp-run-python',
+        'stdio',
+    ],
+)
+
+async def main():
+    print("Connecting to MCP python-runner...")
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            print("Initializing session...")
+            await session.initialize()
+            
+            print("Listing available tools...")
+            tools = await session.list_tools()
+            print(f"Found {len(tools.tools)} tools")
+            print(f"Tool name: {tools.tools[0].name}")
+            
+            print("\nRunning Python code with numpy dependency...")
+            result = await session.call_tool('run_python_code', {'python_code': code})
+            
+            print("\nResult:")
+            print(result.content[0].text)
+            
+            if "success" in result.content[0].text:
+                print("\n✅ MCP Python runner example successful!")
+            else:
+                print("\n❌ MCP Python runner example failed!")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/run_python_code
+++ b/scripts/run_python_code
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Simple wrapper to run Python code with MCP Python runner
+
+# Pass all arguments to the Python script
+python3 "$(dirname "$0")/run_python_code.py" "$@"

--- a/scripts/run_python_code.py
+++ b/scripts/run_python_code.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+Simple utility to execute Python code via MCP Python runner
+"""
+import asyncio
+import sys
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# Get code from command line arguments
+if len(sys.argv) < 2:
+    print("Usage: run_python_code.py <python_code>")
+    sys.exit(1)
+
+# Join all arguments as the code to run
+code = " ".join(sys.argv[1:])
+
+# Configure server parameters
+server_params = StdioServerParameters(
+    command='deno',
+    args=[
+        'run',
+        '-N',
+        '-R=node_modules',
+        '-W=node_modules',
+        '--node-modules-dir=auto',
+        'jsr:@pydantic/mcp-run-python',
+        'stdio',
+    ],
+)
+
+async def main():
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            
+            # Run the code
+            result = await session.call_tool('run_python_code', {'python_code': code})
+            
+            # Extract and print the result
+            response_text = result.content[0].text
+            
+            # Parse the response to get just the return value
+            if "<return_value>" in response_text and "</return_value>" in response_text:
+                start = response_text.find("<return_value>") + len("<return_value>")
+                end = response_text.find("</return_value>")
+                return_value = response_text[start:end].strip()
+                print(return_value)
+            else:
+                print(response_text)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "isolated-pymcp"
+version = "0.1.0"
+source = { editable = "." }


### PR DESCRIPTION
## Summary
- Switch package management from Poetry to UV with Python 3.11
- Add standalone MCP Python runner scripts for executing code in isolation
- Update Makefile with UV-related commands
- Update installation scripts to use UV instead of Poetry
- Add gitignore entries for UV files

## Test plan
1. Run  to verify direct code execution
2. Run  to test full MCP Python runner integration
3. Verify UV-based package management with Installing development dependencies with UV...
uv pip install -e ".[dev]" and Running pytest...
uv run --python=3.11 -m pytest tests/ 

This PR enables running Python code via MCP runner in isolation from the main container for better performance and security.

Closes #35